### PR TITLE
Fixing Null Pointer Exception in ShowWindow

### DIFF
--- a/src/view_win.cc
+++ b/src/view_win.cc
@@ -45,12 +45,12 @@ public:
 
     web_view_->set_parent_window(hwnd_);
 
+    g_active_views_.push_back(this);
+
     ShowWindow(hwnd_, SW_SHOWNORMAL);
     UpdateWindow(hwnd_);
 
     SetTimer (hwnd_, 0, 15, NULL );
-
-    g_active_views_.push_back(this);
   }
 
   virtual ~ViewWin() {


### PR DESCRIPTION
If the ViewWin isn't added to g_active_views before ShowWindow is called, then it can't be found by the  handle, and consequently there is a null pointer exception. Please fix this. I spent 45 minutes debugging the tutorial when I could have been learning Awesomium.